### PR TITLE
feat/add statistics mechanism

### DIFF
--- a/src/des/des.rs
+++ b/src/des/des.rs
@@ -7,15 +7,15 @@ use crate::event::event::Event;
 use std::collections::BinaryHeap;
 
 pub struct Scheduler {
-    pub current_time: f64,
-    pub runtime: f64,
+    pub current_time: usize,
+    pub runtime: usize,
     pub event_queue: BinaryHeap<Box<dyn Event>>,
 }
 
 impl Scheduler {
-    pub fn new(runtime: f64) -> Scheduler {
+    pub fn new(runtime: usize) -> Scheduler {
         Scheduler {
-            current_time: 0.0,
+            current_time: 0,
             runtime,
             event_queue: BinaryHeap::<Box<dyn Event>>::new(),
         }

--- a/src/environment/bus_world/bus_environment.rs
+++ b/src/environment/bus_world/bus_environment.rs
@@ -265,16 +265,6 @@ impl BusEnvironment {
             .find(|b| b.uid == bus_uid)
             .unwrap(); // unwrap bad.
 
-        // Report stats on Passengers currently loaded
-        let data_point = DataPoint::new(
-            event.get_time_stamp(),
-            bus_at_stop.current_passenger_count() as f64,
-        );
-        stat_recorder.add_statistic(
-            data_point,
-            format!("Bus {}: Passenger Count", bus_at_stop.uid),
-        );
-
         for key in &bus_at_stop.serviced_stop_names.clone() {
             if let Some(tentative_onboarders) = stop.waiting_passengers.get_mut(key) {
                 while !tentative_onboarders.is_empty()
@@ -306,6 +296,20 @@ impl BusEnvironment {
             {
                 stop.completed_passengers.append(passengers_getting_off);
             }
+
+            // Report stats on Passengers currently loaded
+            let data_point = DataPoint::new(
+                event.get_time_stamp(),
+                bus_at_stop.current_passenger_count() as f64,
+                String::from("Passengers (ct)"),
+            );
+            stat_recorder.add_statistic(
+                data_point,
+                format!(
+                    "Bus {}: Passenger Count After Trying Unload",
+                    bus_at_stop.uid
+                ),
+            );
         }
     }
 }

--- a/src/environment/bus_world/bus_environment.rs
+++ b/src/environment/bus_world/bus_environment.rs
@@ -166,7 +166,7 @@ impl BusEnvironment {
             // Load initial bus passengers at first stop
             let schedule_load_passengers = Box::new(LoadPassengersEvent::new(
                 event.get_uid() + 1,
-                event.get_time_stamp() + 1.0,
+                event.get_time_stamp() + 1,
                 serde_json::to_string(&LoadPassengersJson::new(bus.uid)).unwrap(),
             ));
             scheduler.add_event(schedule_load_passengers);
@@ -177,7 +177,7 @@ impl BusEnvironment {
             // Schedule the bus to move to the next stop
             let start_bus_route = Box::new(MoveBusToStopEvent::new(
                 event.get_uid() + 1,
-                event.get_time_stamp() + 5.0, // This should be something long for moving between stops
+                event.get_time_stamp() + 5, // This should be something long for moving between stops
                 serde_json::to_string(&bus_routing).unwrap(),
             ));
 
@@ -209,7 +209,7 @@ impl BusEnvironment {
         // Need to scheudle bus loading passengers at this stop
         let schedule_load_passengers = Box::new(LoadPassengersEvent::new(
             event.get_uid() + 1,
-            event.get_time_stamp() + 1.0,
+            event.get_time_stamp() + 1,
             serde_json::to_string(&LoadPassengersJson::new(bus.uid)).unwrap(),
         ));
         scheduler.add_event(schedule_load_passengers);
@@ -219,7 +219,7 @@ impl BusEnvironment {
             let mapping = BusToStopMappingJson::new(bus.uid, next_stop.to_string());
             let next_event = Box::new(MoveBusToStopEvent::new(
                 event.get_uid() + 1, // this is really bad....
-                event.get_time_stamp() + 5.0,
+                event.get_time_stamp() + 5,
                 serde_json::to_string(&mapping).unwrap(),
             ));
             scheduler.add_event(next_event);
@@ -299,13 +299,13 @@ mod tests {
     #[test]
     fn create_bus_world() {
         let mut bus_world = BusEnvironment::new();
-        let mut scheduler = Scheduler::new(100.0);
+        let mut scheduler = Scheduler::new(100);
         assert_eq!(bus_world.bus_stops.len(), 0);
         bus_world.create_bus_stops(1);
         let number_of_buses = NewBusesJson::new(1, 5);
         let event = Box::new(NewBusEvent::new(
             1,
-            0.0,
+            0,
             serde_json::to_string(&number_of_buses).unwrap(),
         ));
         bus_world.apply_event(&mut scheduler, event);

--- a/src/environment/bus_world/bus_world_events/load_passengers.rs
+++ b/src/environment/bus_world/bus_world_events/load_passengers.rs
@@ -6,7 +6,7 @@ use crate::event::event::Event;
 
 pub struct LoadPassengersEvent {
     uid: usize,
-    timestamp: f64,
+    timestamp: usize,
     data: String,
 }
 
@@ -22,7 +22,7 @@ impl LoadPassengersJson {
 }
 
 impl LoadPassengersEvent {
-    pub fn new(uid: usize, timestamp: f64, data: String) -> LoadPassengersEvent {
+    pub fn new(uid: usize, timestamp: usize, data: String) -> LoadPassengersEvent {
         LoadPassengersEvent {
             uid,
             timestamp,
@@ -40,7 +40,7 @@ impl Event for LoadPassengersEvent {
         self.uid
     }
 
-    fn get_time_stamp(&self) -> f64 {
+    fn get_time_stamp(&self) -> usize {
         self.timestamp
     }
 

--- a/src/environment/bus_world/bus_world_events/move_bus_to_stop.rs
+++ b/src/environment/bus_world/bus_world_events/move_bus_to_stop.rs
@@ -17,12 +17,12 @@ impl BusToStopMappingJson {
 
 pub struct MoveBusToStopEvent {
     uid: usize,
-    timestamp: f64,
+    timestamp: usize,
     data: String,
 }
 
 impl MoveBusToStopEvent {
-    pub fn new(uid: usize, timestamp: f64, data: String) -> MoveBusToStopEvent {
+    pub fn new(uid: usize, timestamp: usize, data: String) -> MoveBusToStopEvent {
         MoveBusToStopEvent {
             uid,
             timestamp,
@@ -40,7 +40,7 @@ impl Event for MoveBusToStopEvent {
         self.uid
     }
 
-    fn get_time_stamp(&self) -> f64 {
+    fn get_time_stamp(&self) -> usize {
         self.timestamp
     }
 

--- a/src/environment/bus_world/bus_world_events/new_bus.rs
+++ b/src/environment/bus_world/bus_world_events/new_bus.rs
@@ -20,12 +20,12 @@ impl NewBusesJson {
 
 pub struct NewBusEvent {
     uid: usize,
-    timestamp: f64,
+    timestamp: usize,
     data: String,
 }
 
 impl NewBusEvent {
-    pub fn new(uid: usize, timestamp: f64, data: String) -> NewBusEvent {
+    pub fn new(uid: usize, timestamp: usize, data: String) -> NewBusEvent {
         NewBusEvent {
             uid,
             timestamp,
@@ -43,7 +43,7 @@ impl Event for NewBusEvent {
         self.uid
     }
 
-    fn get_time_stamp(&self) -> f64 {
+    fn get_time_stamp(&self) -> usize {
         self.timestamp
     }
 
@@ -69,10 +69,10 @@ mod tests {
 
     #[test]
     fn create_bus_event() {
-        let bus_event = NewBusEvent::new(1, 0.0, String::from("Hello world!"));
+        let bus_event = NewBusEvent::new(1, 0, String::from("Hello world!"));
         assert_eq!(bus_event.get_event_type(), "NewBus");
         assert_eq!(bus_event.get_uid(), 1);
-        assert_eq!(bus_event.get_time_stamp(), 0.0);
+        assert_eq!(bus_event.get_time_stamp(), 0);
         assert_eq!(bus_event.get_data().unwrap(), "Hello world!");
     }
 }

--- a/src/environment/bus_world/bus_world_events/unload_passengers.rs
+++ b/src/environment/bus_world/bus_world_events/unload_passengers.rs
@@ -6,7 +6,7 @@ use crate::event::event::Event;
 
 pub struct UnloadPassengersEvent {
     uid: usize,
-    timestamp: f64,
+    timestamp: usize,
     data: String,
 }
 
@@ -22,7 +22,7 @@ impl UnloadPassengersJson {
 }
 
 impl UnloadPassengersEvent {
-    pub fn new(uid: usize, timestamp: f64, data: String) -> UnloadPassengersEvent {
+    pub fn new(uid: usize, timestamp: usize, data: String) -> UnloadPassengersEvent {
         UnloadPassengersEvent {
             uid,
             timestamp,
@@ -40,7 +40,7 @@ impl Event for UnloadPassengersEvent {
         self.uid
     }
 
-    fn get_time_stamp(&self) -> f64 {
+    fn get_time_stamp(&self) -> usize {
         self.timestamp
     }
 

--- a/src/environment/environment.rs
+++ b/src/environment/environment.rs
@@ -1,8 +1,13 @@
 use std::fmt::Display;
 
-use crate::{des::des::Scheduler, event::event::Event};
+use crate::{des::des::Scheduler, event::event::Event, statistics::stats::Stats};
 
 pub trait Environment: Display {
-    fn apply_event(&mut self, scheduler: &mut Scheduler, event: Box<dyn Event>);
+    fn apply_event(
+        &mut self,
+        scheduler: &mut Scheduler,
+        stat_recorder: &mut Stats,
+        event: Box<dyn Event>,
+    );
     fn get_state(&self) -> String;
 }

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt::Display};
 pub trait Event: Display {
     fn get_event_type(&self) -> &str;
     fn get_uid(&self) -> usize;
-    fn get_time_stamp(&self) -> f64;
+    fn get_time_stamp(&self) -> usize;
 
     // Stringified JSON to use for arbitrary event handling
     fn get_data(&self) -> Result<String, serde_json::Error>;
@@ -11,12 +11,7 @@ pub trait Event: Display {
 
 impl Ord for dyn Event {
     fn cmp(&self, other: &Self) -> Ordering {
-        let timestamp_ordering = self.get_time_stamp().partial_cmp(&other.get_time_stamp());
-
-        match timestamp_ordering {
-            Some(ordering) => ordering.reverse(),
-            None => Ordering::Equal, // Handle the case where comparison fails
-        }
+        self.get_time_stamp().cmp(&other.get_time_stamp())
     }
 }
 

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -11,7 +11,7 @@ pub trait Event: Display {
 
 impl Ord for dyn Event {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.get_time_stamp().cmp(&other.get_time_stamp())
+        self.get_time_stamp().cmp(&other.get_time_stamp()).reverse()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod statistics {
-    mod data_point;
+    pub mod data_point;
     pub mod stats;
     mod timeseries;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,13 +10,13 @@ fn main() {
     let buses = NewBusesJson::new(5, 19);
     let init_event = Box::new(NewBusEvent::new(
         0,
-        0.0,
+        0,
         serde_json::to_string(&buses).unwrap(),
     ));
 
     env.create_bus_stops(5);
     env.initialize_bus_stops_with_passengers(100);
 
-    let mut sim = Simulation::new(100.0, Box::new(env), init_event);
+    let mut sim = Simulation::new(100, Box::new(env), init_event);
     sim.play_movie(300);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use discrete_event_simulator::{
 fn main() {
     println!("Create a bus world simulation!");
     let mut env = BusEnvironment::new();
-    let buses = NewBusesJson::new(5, 19);
+    let buses = NewBusesJson::new(5, 5);
     let init_event = Box::new(NewBusEvent::new(
         0,
         0,
@@ -18,5 +18,6 @@ fn main() {
     env.initialize_bus_stops_with_passengers(100);
 
     let mut sim = Simulation::new(100, Box::new(env), init_event);
-    sim.play_movie(300);
+    sim.play_movie(100);
+    // sim.run();
 }

--- a/src/simulation/sim.rs
+++ b/src/simulation/sim.rs
@@ -15,7 +15,7 @@ pub struct Simulation {
 
 impl Simulation {
     pub fn new(
-        runtime: f64,
+        runtime: usize,
         environment: Box<dyn Environment>,
         initial_event: Box<dyn Event>,
     ) -> Self {
@@ -70,12 +70,12 @@ mod test {
         let number_of_buses = NewBusesJson::new(10, 15);
         let initial_event = Box::new(NewBusEvent::new(
             1,
-            0.0,
+            0,
             serde_json::to_string(&number_of_buses).unwrap(),
         ));
         let mut env = BusEnvironment::new();
         env.create_bus_stops(1);
-        let mut simulation = Simulation::new(10.0, Box::new(env), initial_event);
+        let mut simulation = Simulation::new(10, Box::new(env), initial_event);
         simulation.run();
         assert_eq!(simulation.environment.get_state(), "Number of buses: 10");
     }

--- a/src/statistics/data_point.rs
+++ b/src/statistics/data_point.rs
@@ -1,17 +1,23 @@
 pub struct DataPoint {
     pub timestamp: usize,
     pub value: f64,
+    pub unit: String,
 }
 
 impl DataPoint {
-    pub fn new(timestamp: usize, value: f64) -> DataPoint {
-        DataPoint { timestamp, value }
+    pub fn new(timestamp: usize, value: f64, unit: String) -> DataPoint {
+        DataPoint {
+            timestamp,
+            value,
+            unit,
+        }
     }
 }
 
 #[test]
 fn create_datapoint() {
-    let data_point = DataPoint::new(0, 1.0);
+    let data_point = DataPoint::new(0, 1.0, String::from("fake_unit"));
     assert_eq!(data_point.timestamp, 0);
     assert_eq!(data_point.value, 1.0);
+    assert_eq!(data_point.unit, "fake_unit");
 }

--- a/src/statistics/stats.rs
+++ b/src/statistics/stats.rs
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn create_add_new_statistic() {
         let mut stats = Stats::new();
-        let data_point = DataPoint::new(0, 1.0);
+        let data_point = DataPoint::new(0, 1.0, String::from("fake_unit"));
         assert_eq!(stats.all_series.len(), 0);
         stats.add_statistic(data_point, "test".to_string());
         assert_eq!(stats.all_series.len(), 1);

--- a/src/statistics/timeseries.rs
+++ b/src/statistics/timeseries.rs
@@ -8,6 +8,7 @@ use std::{
 
 pub struct TimeSeries {
     pub statistic_label: String,
+    pub unit: String,
     pub series: BTreeMap<usize, f64>,
 }
 
@@ -15,11 +16,15 @@ impl TimeSeries {
     pub fn new(statistic_label: String) -> TimeSeries {
         TimeSeries {
             statistic_label,
+            unit: String::from("Unknown"),
             series: BTreeMap::new(),
         }
     }
 
     pub fn add_data_point(&mut self, data_point: &DataPoint) {
+        if self.unit == "Unknown" {
+            self.unit = data_point.unit.clone();
+        }
         self.series.insert(data_point.timestamp, data_point.value);
     }
 }
@@ -36,7 +41,7 @@ impl Display for TimeSeries {
             output.push('=');
         }
         output.push('\n');
-        output.push_str("Timestamp | Value\n");
+        output.push_str(&format!("Timestamp | {}\n", self.unit));
         for (timestamp, value) in &self.series {
             output.push_str(&format!("{:<9} | {}\n", timestamp, value));
         }
@@ -54,7 +59,7 @@ fn create_new_timeseries() {
 #[test]
 fn add_data_point_to_timeseries() {
     let mut time_series = TimeSeries::new("test".to_string());
-    let data_point = DataPoint::new(0, 1.0);
+    let data_point = DataPoint::new(0, 1.0, String::from("fake_unit"));
     time_series.add_data_point(&data_point);
     assert_eq!(time_series.series.len(), 1);
     assert_eq!(time_series.series.get(&0), Some(&1.0));
@@ -63,7 +68,7 @@ fn add_data_point_to_timeseries() {
 #[test]
 fn display_simple_timeseries() {
     let mut time_series = TimeSeries::new("test".to_string());
-    let data_point = DataPoint::new(0, 1.1);
+    let data_point = DataPoint::new(0, 1.1, String::from("fake_unit"));
     time_series.add_data_point(&data_point);
     let expected_output = fs::read_to_string("./test_data/timeseries_simple_expected_display.txt")
         .expect("Failed to read test data for simple timeseries display");
@@ -74,8 +79,8 @@ fn display_simple_timeseries() {
 #[test]
 fn display_multiple_datapoints() {
     let mut time_series = TimeSeries::new("test".to_string());
-    let data_point = DataPoint::new(0, 1.1);
-    let data_point_new = DataPoint::new(20, 2.2);
+    let data_point = DataPoint::new(0, 1.1, String::from("fake_unit"));
+    let data_point_new = DataPoint::new(20, 2.2, String::from("fake_unit"));
     time_series.add_data_point(&data_point);
     time_series.add_data_point(&data_point_new);
     let expected_output =

--- a/test_data/timeseries_multiple_data_expected_display.txt
+++ b/test_data/timeseries_multiple_data_expected_display.txt
@@ -1,6 +1,6 @@
 ====
 test
 ====
-Timestamp | Value
+Timestamp | fake_unit
 0         | 1.1
 20        | 2.2

--- a/test_data/timeseries_simple_expected_display.txt
+++ b/test_data/timeseries_simple_expected_display.txt
@@ -1,5 +1,5 @@
 ====
 test
 ====
-Timestamp | Value
+Timestamp | fake_unit
 0         | 1.1


### PR DESCRIPTION
- fix: runtime as usize rather than f64
- fix: order reverse is needed
- feat: basic stats and bugfix on move event

Bugfix:
 move event is scheduled when we are moving a bus from a previous stop 
 to the current stop. Because of this, we need to increment the bus stop 
 that the bus is at before scheduling the next move.
